### PR TITLE
Initialize Next.js app with Prisma schema and seed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Environment variables
+DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/arteviva"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Dependencies
+node_modules
+
+# Next.js
+.next
+out
+
+# Production
+/build
+
+# Env files
+.env
+.env.local
+.env.*.local
+
+# Prisma
+prisma/dev.db
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Mac
+.DS_Store

--- a/Primei
+++ b/Primei
@@ -1,3 +1,0 @@
-git remote add origin https://github.com/luisantonio124/ArteViva-Sublima-o---certa.git
-git branch -M main
-git push -u origin main

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# ArteViva Sublimação
+
+Projeto inicial utilizando [Next.js 14](https://nextjs.org/), TypeScript, Tailwind CSS, shadcn/ui e Prisma com PostgreSQL.
+
+## Requisitos
+
+- Node.js 18+
+- PostgreSQL
+
+## Instalação
+
+```bash
+npm install
+```
+
+## Configuração
+
+1. Copie o arquivo `.env.example` para `.env` e ajuste a variável `DATABASE_URL` conforme seu banco:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Execute as migrações do Prisma:
+
+   ```bash
+   npx prisma migrate dev
+   ```
+
+3. Popule o banco com dados fictícios:
+
+   ```bash
+   npm run seed
+   # ou
+   npx prisma db seed
+   ```
+
+## Ambiente de desenvolvimento
+
+```bash
+npm run dev
+```
+
+O aplicativo estará disponível em `http://localhost:3000`.

--- a/components.json
+++ b/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "src/app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline"
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10"
+      }
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default"
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "arteviva-sublimacao",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "seed": "ts-node prisma/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.7.0",
+    "@radix-ui/react-slot": "^1.0.2",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "next": "^14.2.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tailwind-merge": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.4.2",
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.45.0",
+    "eslint-config-next": "^14.2.5",
+    "postcss": "^8.4.23",
+    "prisma": "^5.7.0",
+    "tailwindcss": "^3.3.3",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,120 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        String   @id @default(uuid())
+  email     String   @unique
+  name      String?
+  password  String
+  cart      Cart?
+  orders    Order[]
+  reviews   Review[]
+  createdAt DateTime @default(now())
+}
+
+model Category {
+  id        String    @id @default(uuid())
+  name      String    @unique
+  products  Product[]
+  createdAt DateTime  @default(now())
+}
+
+model Product {
+  id          String      @id @default(uuid())
+  name        String
+  description String?
+  price       Decimal     @db.Decimal(10,2)
+  category    Category?   @relation(fields: [categoryId], references: [id])
+  categoryId  String?
+  variations  Variation[]
+  reviews     Review[]
+  createdAt   DateTime    @default(now())
+}
+
+model Variation {
+  id        String   @id @default(uuid())
+  product   Product  @relation(fields: [productId], references: [id])
+  productId String
+  name      String?
+  sku       String   @unique
+  price     Decimal? @db.Decimal(10,2)
+  stock     Int?
+  cartItems CartItem[]
+  orderItems OrderItem[]
+  createdAt DateTime @default(now())
+}
+
+model Cart {
+  id        String     @id @default(uuid())
+  user      User       @relation(fields: [userId], references: [id])
+  userId    String     @unique
+  items     CartItem[]
+  createdAt DateTime   @default(now())
+}
+
+model CartItem {
+  id            String        @id @default(uuid())
+  cart          Cart          @relation(fields: [cartId], references: [id])
+  cartId        String
+  variation     Variation     @relation(fields: [variationId], references: [id])
+  variationId   String
+  quantity      Int           @default(1)
+  customization Customization?
+  createdAt     DateTime      @default(now())
+}
+
+model Customization {
+  id         String   @id @default(uuid())
+  cartItem   CartItem @relation(fields: [cartItemId], references: [id])
+  cartItemId String   @unique
+  text       String?
+  imageUrl   String?
+  createdAt  DateTime @default(now())
+}
+
+model Order {
+  id        String      @id @default(uuid())
+  user      User        @relation(fields: [userId], references: [id])
+  userId    String
+  items     OrderItem[]
+  coupon    Coupon?     @relation(fields: [couponId], references: [id])
+  couponId  String?
+  total     Decimal     @db.Decimal(10,2)
+  createdAt DateTime    @default(now())
+}
+
+model OrderItem {
+  id          String     @id @default(uuid())
+  order       Order      @relation(fields: [orderId], references: [id])
+  orderId     String
+  variation   Variation  @relation(fields: [variationId], references: [id])
+  variationId String
+  quantity    Int
+  price       Decimal    @db.Decimal(10,2)
+  createdAt   DateTime   @default(now())
+}
+
+model Coupon {
+  id       String  @id @default(uuid())
+  code     String  @unique
+  discount Float
+  orders   Order[]
+  createdAt DateTime @default(now())
+}
+
+model Review {
+  id        String   @id @default(uuid())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  product   Product  @relation(fields: [productId], references: [id])
+  productId String
+  rating    Int
+  comment   String?
+  createdAt DateTime @default(now())
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,53 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const canecas = await prisma.category.create({
+    data: { name: "Canecas" }
+  });
+
+  const camisetas = await prisma.category.create({
+    data: { name: "Camisetas" }
+  });
+
+  await prisma.product.create({
+    data: {
+      name: "Caneca Branca",
+      description: "Caneca para sublimação 325ml",
+      price: 25.0,
+      categoryId: canecas.id,
+      variations: {
+        create: [
+          { name: "Sem caixa", sku: "CAN-BRANCA-01", price: 25.0, stock: 100 },
+          { name: "Com caixa", sku: "CAN-BRANCA-02", price: 27.5, stock: 80 }
+        ]
+      }
+    }
+  });
+
+  await prisma.product.create({
+    data: {
+      name: "Camiseta Poliéster",
+      description: "Camiseta para sublimação tamanho M",
+      price: 35.0,
+      categoryId: camisetas.id,
+      variations: {
+        create: [
+          { name: "M", sku: "CAM-PL-M", price: 35.0, stock: 50 },
+          { name: "G", sku: "CAM-PL-G", price: 37.0, stock: 40 }
+        ]
+      }
+    }
+  });
+}
+
+main()
+  .then(() => console.log("Seed completed"))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html,
+body,
+:root {
+  height: 100%;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "ArteViva Sublimação",
+  description: "Loja de sublimação"
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="pt-BR">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,10 @@
+import { Button } from "@/components/ui/button";
+
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <h1 className="mb-4 text-4xl font-bold">ArteViva Sublimação</h1>
+      <Button>Explore</Button>
+    </main>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from "tailwindcss";
+import defaultTheme from "tailwindcss/defaultTheme";
+
+const config: Config = {
+  content: [
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./lib/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {"@/*": ["./src/*"]}
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 project with TypeScript, Tailwind CSS and shadcn/ui
- add Prisma setup for PostgreSQL with core commerce models
- include seeding script and documentation for local setup

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@prisma%2fclient)*
- `npm test` *(fails: Missing script: "test")*
- `npx prisma generate` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*

------
https://chatgpt.com/codex/tasks/task_e_6898f94a8e008325b0c960caa8d04a1a