### PR TITLE
Add catalog and product pages with Prisma-backed API

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    log: ['query', 'info', 'warn', 'error'],
+  });
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+
+export default prisma;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  images: {
+    domains: ["via.placeholder.com"],
+  }
 };
 
 export default nextConfig;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,8 +28,10 @@ model Category {
 model Product {
   id          String      @id @default(uuid())
   name        String
+  slug        String      @unique
   description String?
   price       Decimal     @db.Decimal(10,2)
+  imageUrl    String?
   category    Category?   @relation(fields: [categoryId], references: [id])
   categoryId  String?
   variations  Variation[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -14,8 +14,10 @@ async function main() {
   await prisma.product.create({
     data: {
       name: "Caneca Branca",
+      slug: "caneca-branca",
       description: "Caneca para sublimação 325ml",
       price: 25.0,
+      imageUrl: "https://via.placeholder.com/300",
       categoryId: canecas.id,
       variations: {
         create: [
@@ -29,8 +31,10 @@ async function main() {
   await prisma.product.create({
     data: {
       name: "Camiseta Poliéster",
+      slug: "camiseta-poliester",
       description: "Camiseta para sublimação tamanho M",
       price: 35.0,
+      imageUrl: "https://via.placeholder.com/300",
       categoryId: camisetas.id,
       variations: {
         create: [

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET() {
+  const categories = await prisma.category.findMany({ orderBy: { name: 'asc' } });
+  return NextResponse.json(categories);
+}

--- a/src/app/api/products/[slug]/route.ts
+++ b/src/app/api/products/[slug]/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { slug: string } }
+) {
+  const product = await prisma.product.findUnique({
+    where: { slug: params.slug },
+    include: { variations: true, category: true },
+  });
+
+  if (!product) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(product);
+}

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const page = parseInt(searchParams.get('page') ?? '1', 10);
+  const pageSize = parseInt(searchParams.get('pageSize') ?? '12', 10);
+  const search = searchParams.get('search');
+  const category = searchParams.get('category');
+  const minPrice = searchParams.get('minPrice');
+  const maxPrice = searchParams.get('maxPrice');
+
+  const where: any = {};
+  if (search) {
+    where.name = { contains: search, mode: 'insensitive' };
+  }
+  if (category) {
+    where.category = { name: { equals: category } };
+  }
+  if (minPrice || maxPrice) {
+    where.price = {
+      gte: minPrice ? parseFloat(minPrice) : undefined,
+      lte: maxPrice ? parseFloat(maxPrice) : undefined,
+    };
+  }
+
+  const [products, total] = await Promise.all([
+    prisma.product.findMany({
+      where,
+      include: { variations: true, category: true },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.product.count({ where }),
+  ]);
+
+  return NextResponse.json({ products, total });
+}

--- a/src/app/catalogo/page.tsx
+++ b/src/app/catalogo/page.tsx
@@ -1,0 +1,113 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+interface CatalogPageProps {
+  searchParams: { [key: string]: string | string[] | undefined };
+}
+
+const PAGE_SIZE = 6;
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+
+export default async function CatalogPage({ searchParams }: CatalogPageProps) {
+  const page = Number(searchParams.page) || 1;
+  const search = typeof searchParams.search === 'string' ? searchParams.search : '';
+  const category = typeof searchParams.category === 'string' ? searchParams.category : '';
+  const minPrice = typeof searchParams.minPrice === 'string' ? searchParams.minPrice : '';
+  const maxPrice = typeof searchParams.maxPrice === 'string' ? searchParams.maxPrice : '';
+
+  const query = new URLSearchParams({
+    page: page.toString(),
+    pageSize: PAGE_SIZE.toString(),
+  });
+  if (search) query.set('search', search);
+  if (category) query.set('category', category);
+  if (minPrice) query.set('minPrice', minPrice);
+  if (maxPrice) query.set('maxPrice', maxPrice);
+
+  const [productsRes, categoriesRes] = await Promise.all([
+    fetch(`${baseUrl}/api/products?${query.toString()}`, { cache: 'no-store' }),
+    fetch(`${baseUrl}/api/categories`, { cache: 'no-store' }),
+  ]);
+
+  const { products, total } = await productsRes.json();
+  const categories = await categoriesRes.json();
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  return (
+    <div className="p-4 space-y-4">
+      <form className="flex flex-wrap gap-2">
+        <input
+          name="search"
+          defaultValue={search}
+          placeholder="Buscar..."
+          className="border p-2 rounded"
+        />
+        <select name="category" defaultValue={category} className="border p-2 rounded">
+          <option value="">Todas as categorias</option>
+          {categories.map((cat: any) => (
+            <option key={cat.id} value={cat.name}>
+              {cat.name}
+            </option>
+          ))}
+        </select>
+        <input
+          type="number"
+          name="minPrice"
+          placeholder="Preço mínimo"
+          defaultValue={minPrice}
+          className="border p-2 rounded w-32"
+        />
+        <input
+          type="number"
+          name="maxPrice"
+          placeholder="Preço máximo"
+          defaultValue={maxPrice}
+          className="border p-2 rounded w-32"
+        />
+        <Button type="submit">Filtrar</Button>
+      </form>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {products.map((product: any) => (
+          <div key={product.id} className="border rounded p-4 flex flex-col">
+            {product.imageUrl && (
+              <Image
+                src={product.imageUrl}
+                alt={product.name}
+                width={300}
+                height={300}
+                className="object-cover mb-2 rounded"
+              />
+            )}
+            <h3 className="font-semibold">{product.name}</h3>
+            <p className="text-sm text-muted-foreground">
+              {product.variations.map((v: any) => v.name).join(', ')}
+            </p>
+            <p className="text-lg font-bold mt-auto">
+              R${Number(product.price).toFixed(2)}
+            </p>
+            <Button asChild className="mt-2">
+              <Link href={`/produto/${product.slug}`}>Personalizar</Link>
+            </Button>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        {Array.from({ length: totalPages }, (_, i) => {
+          const p = i + 1;
+          const q = new URLSearchParams(query);
+          q.set('page', p.toString());
+          return (
+            <Link
+              key={p}
+              href={`/catalogo?${q.toString()}`}
+              className={`px-3 py-1 border rounded ${p === page ? 'bg-primary text-primary-foreground' : ''}`}
+            >
+              {p}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/produto/[slug]/page.tsx
+++ b/src/app/produto/[slug]/page.tsx
@@ -1,0 +1,44 @@
+import Image from 'next/image';
+import { Button } from '@/components/ui/button';
+
+interface ProductPageProps {
+  params: { slug: string };
+}
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+
+export default async function ProductPage({ params }: ProductPageProps) {
+  const res = await fetch(`${baseUrl}/api/products/${params.slug}`, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error('Falha ao carregar produto');
+  }
+  const product = await res.json();
+
+  return (
+    <div className="p-4 space-y-4">
+      {product.imageUrl && (
+        <Image
+          src={product.imageUrl}
+          alt={product.name}
+          width={400}
+          height={400}
+          className="rounded"
+        />
+      )}
+      <h1 className="text-2xl font-bold">{product.name}</h1>
+      <p>{product.description}</p>
+      <p className="text-xl font-semibold">R${Number(product.price).toFixed(2)}</p>
+      <div>
+        <h2 className="font-semibold mb-1">Atributos</h2>
+        <ul className="list-disc ml-5">
+          {product.variations.map((v: any) => (
+            <li key={v.id}>
+              {v.name} - R${Number(v.price ?? product.price).toFixed(2)}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <Button>Personalizar</Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend Prisma product schema with slug and imageUrl
- expose API routes for products and categories with filters and pagination
- implement catalog and product detail pages with "Personalizar" action

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Configuring Next.js via 'next.config.ts' is not supported)*
- `npm run build` *(fails: Configuring Next.js via 'next.config.ts' is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6898fd7a75b083258e1feab7c22d904f