### PR TITLE
feat: add product customization editor and cart API

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,8 @@ model Customization {
   cartItem   CartItem @relation(fields: [cartItemId], references: [id])
   cartItemId String   @unique
   text       String?
+  textColor  String?
+  fontFamily String?
   imageUrl   String?
   createdAt  DateTime @default(now())
 }

--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+  const variationId = formData.get('variationId') as string;
+  const text = (formData.get('text') as string) || null;
+  const textColor = (formData.get('textColor') as string) || null;
+  const fontFamily = (formData.get('fontFamily') as string) || null;
+  const file = formData.get('image') as File | null;
+
+  let imageUrl: string | undefined;
+  if (file) {
+    if (!['image/png', 'image/jpeg'].includes(file.type)) {
+      return NextResponse.json(
+        { error: 'Tipo de arquivo inválido' },
+        { status: 400 }
+      );
+    }
+    if (file.size > 10 * 1024 * 1024) {
+      return NextResponse.json(
+        { error: 'Arquivo excede 10MB' },
+        { status: 400 }
+      );
+    }
+    const bytes = await file.arrayBuffer();
+    const buffer = Buffer.from(bytes);
+    const uploadDir = path.join(process.cwd(), 'public', 'uploads');
+    await fs.mkdir(uploadDir, { recursive: true });
+    const filename = `${Date.now()}-${file.name}`;
+    const filepath = path.join(uploadDir, filename);
+    await fs.writeFile(filepath, buffer);
+    imageUrl = `/uploads/${filename}`;
+  }
+
+  // Usuário e carrinho de demonstração
+  const user = await prisma.user.upsert({
+    where: { email: 'demo@demo.com' },
+    update: {},
+    create: { email: 'demo@demo.com', password: 'demo' },
+  });
+
+  const cart = await prisma.cart.upsert({
+    where: { userId: user.id },
+    update: {},
+    create: { userId: user.id },
+  });
+
+  const item = await prisma.cartItem.create({
+    data: {
+      cartId: cart.id,
+      variationId,
+      customization: {
+        create: {
+          text,
+          textColor,
+          fontFamily,
+          imageUrl,
+        },
+      },
+    },
+    include: { customization: true },
+  });
+
+  return NextResponse.json(item);
+}

--- a/src/app/personalizar/[tipo]/Editor.tsx
+++ b/src/app/personalizar/[tipo]/Editor.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { Button } from '@/components/ui/button';
+
+interface EditorProps {
+  product: any;
+}
+
+export default function Editor({ product }: EditorProps) {
+  const [text, setText] = useState('');
+  const [textColor, setTextColor] = useState('#000000');
+  const [fontFamily, setFontFamily] = useState('Arial');
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!['image/png', 'image/jpeg'].includes(file.type) || file.size > 10 * 1024 * 1024) {
+      alert('Use PNG ou JPG até 10MB.');
+      return;
+    }
+    setImageFile(file);
+    setImagePreview(URL.createObjectURL(file));
+  };
+
+  const handleAddToCart = async () => {
+    const formData = new FormData();
+    formData.append('variationId', product.variations[0].id);
+    formData.append('text', text);
+    formData.append('textColor', textColor);
+    formData.append('fontFamily', fontFamily);
+    if (imageFile) {
+      formData.append('image', imageFile);
+    }
+    await fetch('/api/cart', { method: 'POST', body: formData });
+    alert('Personalização salva no carrinho!');
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex flex-col md:flex-row gap-4">
+        <div className="relative w-80 h-80 border">
+          {product.imageUrl && (
+            <Image src={product.imageUrl} alt={product.name} fill sizes="320px" className="object-cover" />
+          )}
+          {imagePreview && (
+            <Image src={imagePreview} alt="Preview" fill sizes="320px" className="object-contain" />
+          )}
+          {text && (
+            <span className="absolute top-2 left-2" style={{ color: textColor, fontFamily }}>
+              {text}
+            </span>
+          )}
+        </div>
+        <div className="space-y-2">
+          <div>
+            <label className="block mb-1">Imagem</label>
+            <input type="file" accept="image/png,image/jpeg" onChange={handleFileChange} />
+          </div>
+          <div>
+            <label className="block mb-1">Texto</label>
+            <input value={text} onChange={(e) => setText(e.target.value)} className="border p-1 w-full" />
+          </div>
+          <div>
+            <label className="block mb-1">Cor do texto</label>
+            <input type="color" value={textColor} onChange={(e) => setTextColor(e.target.value)} />
+          </div>
+          <div>
+            <label className="block mb-1">Fonte</label>
+            <select value={fontFamily} onChange={(e) => setFontFamily(e.target.value)} className="border p-1">
+              <option value="Arial">Arial</option>
+              <option value="'Times New Roman'">Times New Roman</option>
+              <option value="Courier New">Courier New</option>
+            </select>
+          </div>
+          <Button onClick={handleAddToCart}>Adicionar ao Carrinho</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/personalizar/[tipo]/page.tsx
+++ b/src/app/personalizar/[tipo]/page.tsx
@@ -1,0 +1,16 @@
+import Editor from './Editor';
+
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+
+interface PageProps {
+  params: { tipo: string };
+}
+
+export default async function PersonalizarPage({ params }: PageProps) {
+  const res = await fetch(`${baseUrl}/api/products/${params.tipo}`, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error('Falha ao carregar produto');
+  }
+  const product = await res.json();
+  return <Editor product={product} />;
+}

--- a/src/app/produto/[slug]/page.tsx
+++ b/src/app/produto/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 
 interface ProductPageProps {
@@ -38,7 +39,9 @@ export default async function ProductPage({ params }: ProductPageProps) {
           ))}
         </ul>
       </div>
-      <Button>Personalizar</Button>
+      <Button asChild>
+        <Link href={`/personalizar/${product.slug}`}>Personalizar</Link>
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add text color and font fields to customizations
- create personalization page with image upload and preview
- implement cart API to store customizations and link to demo user cart

## Testing
- `npm run lint` (fails: Configuring Next.js via 'next.config.ts' is not supported)
- `npx eslint .`
- `npm run build` (fails: Configuring Next.js via 'next.config.ts' is not supported)


------
https://chatgpt.com/codex/tasks/task_e_689900b34710832589657d2a46c9f591